### PR TITLE
CRASH-248: KeyAuthenticationPlugin denied correct key

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/auth/KeyAuthenticationPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/auth/KeyAuthenticationPlugin.java
@@ -91,12 +91,13 @@ public class KeyAuthenticationPlugin extends CRaSHPlugin<KeyAuthenticationPlugin
   }
 
   public boolean authenticate(String username, PublicKey credential) throws Exception {
-    if (authorizedKeys.contains(credential)) {
-      log.log(Level.FINE, "Authenticated " + username + " with public key " + credential);
-      return true;
-    } else {
-      log.log(Level.FINE, "Denied " + username + " with public key " + credential);
-      return false;
+    for (PublicKey authorizedKey : authorizedKeys) {
+      if (authorizedKey.equals(credential)) {
+        log.log(Level.FINE, "Authenticated " + username + " with public key " + credential);
+        return true;
+      }
     }
+    log.log(Level.FINE, "Denied " + username + " with public key " + credential);
+    return false;
   }
 }


### PR DESCRIPTION
From https://jira.exoplatform.org/browse/CRASH-248

------------------------------------

`PublicKey` in authorized keys equals `PublicKey` gets from authentication. Each class of `PublicKey` is different and has different hashcode.
There is `RSAPublicKeyImpl` class in `authorizedKeys` and method parameter credential is instance of `BCRSAPublicKey`. It **can't** be compared as

```java
if (authorizedKeys.contains(credential)) 
```

`LinkedHashSet` use hashcode same as equals for every entry.